### PR TITLE
Return a raw Ondato response

### DIFF
--- a/src/Kyc/Mapper/GetDataMapper.php
+++ b/src/Kyc/Mapper/GetDataMapper.php
@@ -30,7 +30,7 @@ class GetDataMapper implements NormalizerInterface
         }
 
         if (isset($data['requestData'])) {
-            $getDataResponse->setSessionData($this->sessionDataMapper->mapToEntity($data['data']));
+            $getDataResponse->setSessionData($this->sessionDataMapper->mapToEntity($data['requestData']));
         }
 
         if (isset($data['documentData'])) {

--- a/src/KycApiClient.php
+++ b/src/KycApiClient.php
@@ -54,7 +54,7 @@ class KycApiClient
         }
     }
 
-    public function getData(string $identificationId)
+    public function getData(string $identificationId, bool $raw = false)
     {
         $getDataMapper = new GetDataMapper(new SessionDataMapper(), new ParsedDocumentDataMapper());
 
@@ -67,21 +67,18 @@ class KycApiClient
                 ]
             );
 
-            return $getDataMapper->mapToEntity(json_decode($response->getBody()->getContents(), true));
+            $responseData = json_decode($response->getBody()->getContents(), true);
+
+            return $raw ? $responseData : $getDataMapper->mapToEntity($responseData);
         } catch (ClientException $exception) {
             if ($exception->getResponse()->getStatusCode() === 400) {
                 $data = json_decode($exception->getResponse()->getBody()->getContents(), true);
+                $rawData = ['identificationData' => ['status' => $data['status'], 'failReason' => $data['message']]];
 
-                return $getDataMapper->mapToEntity([
-                    'identificationData' => [
-                        'status' => $data['status'],
-                        'failReason' => $data['message']
-                    ]
-                ]);
+                return $raw ? $rawData : $getDataMapper->mapToEntity($rawData);
             }
 
             throw $exception;
         }
     }
-
 }


### PR DESCRIPTION
1. An ability to return response data without mapping. Some returning data couldn't be mapped because of the different structure
2. "requestData" mapping fixed